### PR TITLE
Removed json/add/core because it pollutes the global namespace

### DIFF
--- a/lib/prosperworks/utils.rb
+++ b/lib/prosperworks/utils.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'json/add/core' # enables serializing of Time and other things
 
 module ProsperWorks
 


### PR DESCRIPTION
We started using Prosperworks a few days ago and we found that it changes the way ALL the objects in our app are JSONized:
```
[1] overol:ar(main)> :foo.to_json
=> "\"foo\""
[2] overol:ar(main)> require "prosperworks"
=> true
[3] overol:ar(main)> :foo.to_json
=> "{\"json_class\":\"Symbol\",\"s\":\"foo\"}"
```

This PR removes the require; tests pass.

I'm not sure why it was added in first instance (since the only `#to_json` calls I found were to Prosperworks API and they don't seem to support the `json_class` magic). This seems to come from the https://github.com/treeder/jsonable/blob/master/lib/jsonable.rb but it's not needed 5 years later :)


 