### PR TITLE
renames SerializedEntity#serialize_pw_entity to to_json

### DIFF
--- a/lib/prosperworks/api_operations/connect.rb
+++ b/lib/prosperworks/api_operations/connect.rb
@@ -23,10 +23,10 @@ module ProsperWorks
             request = Net::HTTP::Get.new(uri.request_uri, headers)
           when "post"
             request = Net::HTTP::Post.new(uri.request_uri, headers)
-            request.body = entity.serialize_pw_entity
+            request.body = entity.to_json
           when "put"
             request = Net::HTTP::Put.new(uri.request_uri, headers)
-            request.body = entity.serialize_pw_entity
+            request.body = entity.to_json
           when "delete"
             request = Net::HTTP::Delete.new(uri.request_uri, headers)
           end

--- a/lib/prosperworks/utils.rb
+++ b/lib/prosperworks/utils.rb
@@ -8,7 +8,7 @@ module ProsperWorks
   #
   module SerializeEntity
 
-    def serialize_pw_entity(*a)
+    def to_json(*a)
       result = {}
       self.instance_variables.each do |var|
         trimmed_var = var.to_s.gsub!("@", "")


### PR DESCRIPTION
ProsperWorks API expects JSON
The objects should be to_jsoned (and a specialized `to_json` method is written for SerializeEntity