### PR TITLE
Fix Tests Failing on Ruby 2.3

### DIFF
--- a/lib/prosperworks/client.rb
+++ b/lib/prosperworks/client.rb
@@ -6,10 +6,10 @@ module ProsperWorks
 
     def headers
       {
-        "Content-Type": "application/json",
-        "X-PW-Application": "developer_api",
-        "X-PW-UserEmail": configuration.user_email,
-        "X-PW-AccessToken": configuration.access_token
+        "Content-Type" => "application/json",
+        "X-PW-Application" => "developer_api",
+        "X-PW-UserEmail" => configuration.user_email,
+        "X-PW-AccessToken" => configuration.access_token
       }
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,15 @@ require 'minitest/unit'
 require 'minitest/pride'
 require 'webmock/minitest'
 
+class Minitest::Test
+  def setup
+    ProsperWorks.configure do |config|
+      config.user_email = "test@test.test"
+      config.access_token = "123456789ABCDEFGHI"
+    end
+  end
+end
+
 module Helpers
 
   def headers
@@ -14,7 +23,9 @@ module Helpers
       'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
       'Content-Type'=>'application/json',
       'User-Agent'=>'Ruby',
-      'X-Pw-Application'=>'developer_api'
+      'X-Pw-AccessToken'=>'123456789ABCDEFGHI',
+      'X-Pw-Application'=>'developer_api',
+      'X-Pw-UserEmail'=>'test@test.test'
     }
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ require 'minitest/pride'
 require 'webmock/minitest'
 
 class Minitest::Test
-  def setup
+  def before_setup
     ProsperWorks.configure do |config|
       config.user_email = "test@test.test"
       config.access_token = "123456789ABCDEFGHI"


### PR DESCRIPTION
It looks like commit f7d2b3f5be0b43faad9f3c3ee84e90424242a07f broke the tests for ruby 2.3, with the error:
```
 1) Error:
WebhookTest#test_webhook_get:
NoMethodError: undefined method `strip' for nil:NilClass
    /Users/neeraj/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/net/http/header.rb:18:in `block in initialize_http_header'
    /Users/neeraj/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/net/http/header.rb:16:in `each'
    /Users/neeraj/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/net/http/header.rb:16:in `initialize_http_header'
    /Users/neeraj/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/net/http/generic_request.rb:44:in `initialize'
    /Users/neeraj/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/net/http/request.rb:15:in `initialize'
    /Users/neeraj/repos/prosperworks-ruby/lib/prosperworks/api_operations/connect.rb:23:in `new'
    /Users/neeraj/repos/prosperworks-ruby/lib/prosperworks/api_operations/connect.rb:23:in `block in send_request'
    /Users/neeraj/.rvm/gems/ruby-2.3.1/gems/webmock-3.0.1/lib/webmock/http_lib_adapters/net_http.rb:123:in `start_without_connect'
    /Users/neeraj/.rvm/gems/ruby-2.3.1/gems/webmock-3.0.1/lib/webmock/http_lib_adapters/net_http.rb:150:in `start'
    /Users/neeraj/repos/prosperworks-ruby/lib/prosperworks/api_operations/connect.rb:20:in `send_request'
    /Users/neeraj/repos/prosperworks-ruby/lib/prosperworks/api_operations/find.rb:12:in `find'
    /Users/neeraj/repos/prosperworks-ruby/test/prosperworks/integration/webhook_test.rb:30:in `test_webhook_get'
```

This PR restores the configuration setup for tests, and moves the setup to `before_setup` in order to ensure the same state for each test.