### PR TITLE
Allow user-inputted credentials for bin/console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+
+.pw_credentials.txt

--- a/README.md
+++ b/README.md
@@ -110,7 +110,19 @@ The response will either be an instance of `ProsperWorks::Errors`, or the entity
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive Ruby shell.
+
+### `bin/console`
+
+To use the gem in an interactive Ruby shell, you can run `bin/console`. To include your ProsperWorks API credentials (`user_name` and `access_token`) you can either:
+
+1. Use ENV variables:
+```
+USER_EMAIL=<your_email> ACCESS_TOKEN=<your_access_token> bin/console
+```
+2. Store them in a text file named `.pw_credentials.txt` in the root directory of this repository. The first line must be your user_email and the second line must be your access_token. Nothing else may be in this file. At startup, `bin/console` will read and use these values. And this file *must not* be checked into git; it has been included in `.gitignore` for this very reason.
+
+### Local Installation
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 

--- a/bin/console
+++ b/bin/console
@@ -2,13 +2,18 @@
 
 require "bundler/setup"
 require "prosperworks"
-
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
 require "irb"
+
+credential_filename = '.pw_credentials.txt'
+if File.file?(credential_filename)
+  contents     = (File.read(credential_filename) || "").split(/\n/)
+  user_email   = contents[0] if contents.length > 0
+  access_token = contents[1] if contents.length > 1
+end
+
+ProsperWorks.configure do |config|
+  config.user_email = (ENV['USER_EMAIL'] || user_email)
+  config.access_token = (ENV['ACCESS_TOKEN'] || access_token)
+end
+
 IRB.start(__FILE__)

--- a/bin/console
+++ b/bin/console
@@ -7,7 +7,7 @@ require "irb"
 credential_filename = '.pw_credentials.txt'
 if File.file?(credential_filename)
   contents     = (File.read(credential_filename) || "").split(/\n/)
-  user_email   = contents[0] if contents.length > 0
+  user_email   = contents[0] unless contents.empty?
   access_token = contents[1] if contents.length > 1
 end
 


### PR DESCRIPTION
Let users input their PW user_email & access_token credentials when using `bin/console`. 

The update to the README (included in this PR) has the full change.