### PR TITLE
Properly Handle Error Response

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   DisplayCopNames: true
 
+Metric/AbcSize:
+  Max: 25
+
 Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 

--- a/lib/prosperworks/api_operations/connect.rb
+++ b/lib/prosperworks/api_operations/connect.rb
@@ -50,25 +50,25 @@ module ProsperWorks
           end
           entity
         when Errors::BadRequest.status_code
-          Errors::BadRequest
+          Errors::BadRequest.new
         when Errors::Unauthorized.status_code
-          Errors::Unauthorized
+          Errors::Unauthorized.new
         when Errors::Forbidden.status_code
-          Errors::Forbidden
+          Errors::Forbidden.new
         when Errors::NotFound.status_code
-          Errors::NotFound
+          Errors::NotFound.new
         when Errors::Unprocessable.status_code
-          Errors::Unprocessable
+          Errors::Unprocessable.new
         when Errors::RateLimit.status_code
-          Errors::RateLimit
+          Errors::RateLimit.new
         else
-          Errors::ServerError
+          Errors::ServerError.new
         end
       end
 
       def handle_multiple_response(response)
         result = handle_response(nil, response)
-        if result.is_a?(ProsperWorks::Errors)
+        if result.is_a?(ProsperWorks::Errors::Base)
           # pass the error along
           result
         else

--- a/lib/prosperworks/api_operations/connect.rb
+++ b/lib/prosperworks/api_operations/connect.rb
@@ -42,7 +42,6 @@ module ProsperWorks
           json_object = JSON.parse(response.body)
           return json_object if json_object.is_a?(Array)
 
-
           json_object.each_pair do |key, value|
             if entity.respond_to?(key.to_sym)
               entity.send("#{key}=", value)

--- a/test/prosperworks/unit/api_operations/connect_test.rb
+++ b/test/prosperworks/unit/api_operations/connect_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class ConnectTest < Minitest::Test
-  include Helpers  
+  include Helpers
 
   def test_get_uri
     # get_uri is aliased in Helpers
@@ -9,61 +9,60 @@ class ConnectTest < Minitest::Test
 
     assert_equal "https://api.prosperworks.com/developer_api/v1/test_api/14", uri.to_s
   end
-  
-  def bad_request_response
+
+  def test_bad_request_response
     id = 2
-    url = get_uri(ProsperWorks::Contact.api_name, id)
+    url = get_uri(ProsperWorks::Person.api_name, id)
     stub_request(:get, url).with(headers: headers).to_return(status: 400, body: "")
 
-    assert_equal Errors::BadRequest, ProsperWorks::Contact.find(id)
+    assert ProsperWorks::Person.find(id).is_a?(ProsperWorks::Errors::BadRequest)
   end
 
-  def forbidden_response
+  def test_forbidden_response
     id = 2
-    url = get_uri(ProsperWorks::Contact.api_name, id)
-    stub_request(:get, url).with(headers: headers).to_return(status: 401, body: "")
+    url = get_uri(ProsperWorks::Person.api_name, id)
+    stub_request(:get, url).with(headers: headers).to_return(status: 403, body: "")
 
-    assert_equal Errors::Forbidden, ProsperWorks::Contact.find(id)
+    assert ProsperWorks::Person.find(id).is_a?(ProsperWorks::Errors::Forbidden)
   end
 
-  def not_found_response
+  def test_not_found_response
     id = 2
-    url = get_uri(ProsperWorks::Contact.api_name, id)
+    url = get_uri(ProsperWorks::Person.api_name, id)
     stub_request(:get, url).with(headers: headers).to_return(status: 404, body: "")
 
-    assert_equal Errors::NotFound, ProsperWorks::Contact.find(id)
+    assert ProsperWorks::Person.find(id).is_a?(ProsperWorks::Errors::NotFound)
   end
 
-  def rate_limit_response
+  def test_rate_limit_response
     id = 2
-    url = get_uri(ProsperWorks::Contact.api_name, id)
+    url = get_uri(ProsperWorks::Person.api_name, id)
     stub_request(:get, url).with(headers: headers).to_return(status: 429, body: "")
 
-    assert_equal Errors::RateLimit, ProsperWorks::Contact.find(id)
+    assert ProsperWorks::Person.find(id).is_a?(ProsperWorks::Errors::RateLimit)
   end
 
-  def server_error_response
+  def test_server_error_response
     id = 2
-    url = get_uri(ProsperWorks::Contact.api_name, id)
+    url = get_uri(ProsperWorks::Person.api_name, id)
     stub_request(:get, url).with(headers: headers).to_return(status: 500, body: "")
 
-    assert_equal Errors::ServerError, ProsperWorks::Contact.find(id)
+    assert ProsperWorks::Person.find(id).is_a?(ProsperWorks::Errors::ServerError)
   end
 
-  def unauthorized_response
+  def test_unauthorized_response
     id = 2
-    url = get_uri(ProsperWorks::Contact.api_name, id)
+    url = get_uri(ProsperWorks::Person.api_name, id)
     stub_request(:get, url).with(headers: headers).to_return(status: 401, body: "")
 
-    assert_equal Errors::Unauthorized, ProsperWorks::Contact.find(id)
+    assert ProsperWorks::Person.find(id).is_a?(ProsperWorks::Errors::Unauthorized)
   end
 
-  def unprocessable_response
+  def test_unprocessable_response
     id = 2
-    url = get_uri(ProsperWorks::Contact.api_name, id)
-    stub_request(:get, url).with(headers: headers).to_return(status: 429, body: "")
+    url = get_uri(ProsperWorks::Person.api_name, id)
+    stub_request(:get, url).with(headers: headers).to_return(status: 422, body: "")
 
-    assert_equal Errors::Unprocessable, ProsperWorks::Contact.find(id)
+    assert ProsperWorks::Person.find(id).is_a?(ProsperWorks::Errors::Unprocessable)
   end
-
 end


### PR DESCRIPTION
There is a bug in the code that handles error responses. When an error response is detected, the code returns the appropriate error class itself, instead of an instance of this class.

As such, the logic to detect and run the error for `handle_multiple_response` does not properly catch the error, and instead tries to treat the response as valid. This produces a runtime error.

The fix is to return an instance of the appropriate error class, which is then properly caught by the handling logic.