### PR TITLE
Add support for custom field definitions

### DIFF
--- a/lib/prosperworks.rb
+++ b/lib/prosperworks.rb
@@ -34,6 +34,7 @@ require 'prosperworks/task'
 require 'prosperworks/version'
 require 'prosperworks/webhook'
 require 'prosperworks/loss_reason'
+require 'prosperworks/custom_field_definition'
 
 module ProsperWorks
 

--- a/lib/prosperworks.rb
+++ b/lib/prosperworks.rb
@@ -35,6 +35,7 @@ require 'prosperworks/version'
 require 'prosperworks/webhook'
 require 'prosperworks/loss_reason'
 require 'prosperworks/custom_field_definition'
+require 'prosperworks/related_link'
 
 module ProsperWorks
 

--- a/lib/prosperworks/api_operations/list.rb
+++ b/lib/prosperworks/api_operations/list.rb
@@ -6,8 +6,9 @@ module ProsperWorks
 
       include ApiOperations::Connect
 
-      def list
+      def list(query_params = {})
         uri = get_uri(api_name)
+        uri.query = URI.encode_www_form(query_params)
 
         response = send_request("get", uri)
         handle_multiple_response(response)

--- a/lib/prosperworks/custom_field_definition.rb
+++ b/lib/prosperworks/custom_field_definition.rb
@@ -1,0 +1,14 @@
+module ProsperWorks
+  class CustomFieldDefinition < Base
+    extend ApiOperations::List
+
+    attr_accessor :name,
+                  :data_type,
+                  :currency,
+                  :options
+
+    def self.api_name
+      "custom_field_definitions"
+    end
+  end
+end

--- a/lib/prosperworks/related_link.rb
+++ b/lib/prosperworks/related_link.rb
@@ -1,0 +1,13 @@
+module ProsperWorks
+  class RelatedLink < Base
+    extend ApiOperations::List
+
+    attr_accessor :source,
+                  :target,
+                  :custom_field_definition_id
+
+    def self.api_name
+      "related_links"
+    end
+  end
+end


### PR DESCRIPTION
Eventually we could replace the actual custom field responses on individual objects with the actual names using this data, but I need this for a project in the short term.