### PR TITLE
Fix cop name Metric->Metrics

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   DisplayCopNames: true
 
-Metric/AbcSize:
+Metrics/AbcSize:
   Max: 25
 
 Layout/EmptyLinesAroundModuleBody:


### PR DESCRIPTION
The correct name for this cop is `Metrics/AbcSize` not `Metric/AbcSize`